### PR TITLE
[add] #3 UITableView押下のView作成。画像と言語名を表記

### DIFF
--- a/SwiftUITableView.xcodeproj/xcuserdata/murakami.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/SwiftUITableView.xcodeproj/xcuserdata/murakami.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "EE1321A5-4B2F-4FC4-AD60-80E93D1C009A"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/SwiftUITableView/ContentView.swift
+++ b/SwiftUITableView/ContentView.swift
@@ -51,20 +51,82 @@ struct ContentView: View {
                         .fontWeight(.heavy)
                     ){
                         ForEach(self.players[section]){ player in
-                            HStack{
-                                player.image
-                                    .resizable()
-                                    .scaledToFill()
-                                    .clipShape(Circle())    //画像を丸くする
-                                    .frame(width: 50, height: 50)   //画像サイズを指定
-                                Text(player.name)
-                                    .font(.headline)
-                                    .padding(.leading, 20)  //画像と文字の間を空ける
-                            }
+                            
+                            //Cell呼び出し
+                            PlayerRow(player: player, generation: self.switchHeaderTitle(section: section))
                         }
                     }.frame(height: 70) //セクションの高さを調整
                 }
             }.navigationBarTitle(Text("プログラミング言語"))
+        }
+    }
+    
+    
+    //cellに関する情報をこのviewに記載
+    struct PlayerRow: View {
+        
+        let player : Player
+        let generation : String
+        
+        var body : some View{
+            HStack{
+                //関数呼び出し(cell押下のビューを表示)
+                NavigationLink(destination: PlayerDetail(player: player, generation: generation)){
+                    player.image
+                        .resizable()
+                        .scaledToFill()
+                        .clipShape(Circle())    //画像を丸くする
+                        .frame(width: 50, height: 50)   //画像サイズを指定
+                    Text(player.name)
+                        .font(.headline)
+                        .padding(.leading, 20)  //画像と文字の間を空ける
+                }
+            }
+        }
+    }
+    
+    //cell押下のビューを表示
+    //詳細情報を表示
+    struct PlayerDetail : View{
+        
+        let player : Player
+        let generation : String
+        
+        var body : some View{
+            
+            NavigationView{
+                VStack{
+                    //画像表示と画像設定
+                    player.image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: 400, height: 400, alignment: .top)
+                        .cornerRadius(20)
+                        .padding(.init(top:0,leading: 0,bottom: 0,trailing: 50))
+            
+                    HStack{
+                        Text(player.name)
+                            .font(.system(size: 30, weight: .heavy))
+                            .padding(.top, -60)
+                            .padding(.trailing, 20)
+//                            .foregroundColor(.white)
+                    }
+                    .frame(width: 330, height: 60, alignment: .trailing)
+                    //横並びに文字を表示
+                    HStack{
+                        Text("どんな言語?:")
+                            .font(.system(size: 20, weight: .medium))
+                        Text(generation)
+                            .font(.system(size: 20, weight: .heavy))
+                            .padding(.leading, 5)
+                    }
+//                    .frame(width: 400, height: 40, alignment: .leading)
+                    .padding(.leading, 20)
+                    Spacer()
+                }.padding(.top, -80)        //画像の配置を調整
+            }.navigationBarTitle(Text("プログラミング言語"),displayMode: .inline) //displaymodeで表示のさせ方を変更できる
+            
+            
         }
     }
     


### PR DESCRIPTION
### 概要
issue #1 
UITableView押下のView作成。そのViewに画像と言語名を表示

### 変更内容
- cell押下時のView作成。

### レビューでみて欲しいこと
- 押したcellと詳細ページとの紐付けがされているかどうか

### スクリーンショット
<img src="https://user-images.githubusercontent.com/33933366/93664194-101ce400-faa8-11ea-9e50-22256ee60e03.png" width="400">


